### PR TITLE
Document sequence packing and extend benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ poetry.toml
 
 # LSP config files
 pyrightconfig.json
+
+.vscode

--- a/README_Extended.md
+++ b/README_Extended.md
@@ -204,6 +204,47 @@ UEFA Nations League => competitions
 European Championship => competitions
 ```
 
+### ⚡ Accelerating Inference with Sequence Packing
+
+Sequence packing allows GLiNER to combine multiple short requests into a single transformer pass while keeping a block-diagonal attention mask. This drastically reduces the number of padding tokens the encoder needs to process and yields higher throughput.
+
+1. **Configure packing once for all predictions**
+
+   ```python
+   from gliner import GLiNER, InferencePackingConfig
+
+   model = GLiNER.from_pretrained("urchade/gliner_medium-v2.1", map_location="cuda")
+
+   packing_cfg = InferencePackingConfig(
+       max_length=512,
+       sep_token_id=model.data_processor.transformer_tokenizer.sep_token_id,
+       streams_per_batch=1,
+   )
+
+   # Enable packing for every subsequent `run`/`predict_*` call.
+   model.configure_inference_packing(packing_cfg)
+
+   texts = ["Email CEO to approve budget", "Schedule yearly medical checkup"]
+   labels = ["person", "organization", "action"]
+
+   predictions = model.run(texts, labels, batch_size=16)
+   ```
+
+   You can override or disable the default configuration on a per-call basis by passing `packing_config=<new_cfg>` or `packing_config=None` respectively when invoking `model.run` or `model.predict_entities`.
+
+2. **Benchmark the impact**
+
+   The `bench/bench_infer_packing.py` script can now stress the full GLiNER pipeline in addition to encoder-only Hugging Face models:
+
+   ```bash
+   python bench/bench_infer_packing.py \
+       --gliner_model urchade/gliner_medium-v2.1 \
+       --gliner_labels person organization location \
+       --batch_size 64 --scenario short_zipf --device cuda
+   ```
+
+   The benchmark prints JSON metrics and a human-readable table comparing baseline and packed execution, including padding ratios, tokens processed per second, and the achieved speedup.
+
 ### 🔌 Usage with spaCy
 
 GLiNER can be seamlessly integrated with spaCy. To begin, install the `gliner-spacy` library via pip:

--- a/README_Extended.md
+++ b/README_Extended.md
@@ -240,6 +240,11 @@ Sequence packing allows GLiNER to combine multiple short requests into a single 
    python bench/bench_gliner_e2e.py
    ```
 
+   To isolate and measure the impact on the encoder:
+   ```bash
+   python bench/bench_infer_packing.py --batch_size 32 --scenario short_zipf
+   ```
+
 ### 🔌 Usage with spaCy
 
 GLiNER can be seamlessly integrated with spaCy. To begin, install the `gliner-spacy` library via pip:

--- a/README_Extended.md
+++ b/README_Extended.md
@@ -234,7 +234,7 @@ Sequence packing allows GLiNER to combine multiple short requests into a single 
 
 2. **Benchmark the impact**
 
-   The `bench/bench_infer_packing.py` script can now stress the full GLiNER pipeline in addition to encoder-only Hugging Face models:
+   The `bench/bench_gliner_e2e.py` script can stress the full GLiNER pipeline in addition to encoder-only Hugging Face models:
 
    ```bash
    python bench/bench_gliner_e2e.py

--- a/README_Extended.md
+++ b/README_Extended.md
@@ -237,13 +237,8 @@ Sequence packing allows GLiNER to combine multiple short requests into a single 
    The `bench/bench_infer_packing.py` script can now stress the full GLiNER pipeline in addition to encoder-only Hugging Face models:
 
    ```bash
-   python bench/bench_infer_packing.py \
-       --gliner_model urchade/gliner_medium-v2.1 \
-       --gliner_labels person organization location \
-       --batch_size 64 --scenario short_zipf --device cuda
+   python bench/bench_gliner_e2e.py
    ```
-
-   The benchmark prints JSON metrics and a human-readable table comparing baseline and packed execution, including padding ratios, tokens processed per second, and the achieved speedup.
 
 ### 🔌 Usage with spaCy
 

--- a/bench/bench_gliner_e2e.py
+++ b/bench/bench_gliner_e2e.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+"""Compare GLiNER NER predictions with and without inference packing."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import textwrap
+import time
+from typing import List, Sequence
+
+import torch
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from gliner import GLiNER, InferencePackingConfig
+
+
+DEFAULT_TEXTS: List[str] = [
+    "OpenAI launched GPT-4o in San Francisco, while Sam Altman discussed future plans on CNBC.",
+    "NASA announced that the Artemis II mission will send astronauts around the Moon in 2025.",
+    "Amazon acquired Whole Foods for $13.7 billion and expanded grocery delivery across the United States.",
+    "Taylor Swift kicked off her Eras Tour in Glendale before headlining shows across Europe in 2024.",
+    "Elon Musk unveiled Tesla’s Cybertruck at a launch event in Los Angeles in 2019.",
+    "Apple introduced the Vision Pro headset at WWDC 2023 in Cupertino.",
+    "Google I/O 2022 showcased advances in AI, including new features for Google Translate.",
+    "Lionel Messi signed with Inter Miami in 2023, changing the face of Major League Soccer in the United States.",
+    "The FIFA World Cup 2022 was held in Qatar, attracting millions of fans worldwide.",
+    "Meta rebranded from Facebook in October 2021 to emphasize its focus on the Metaverse.",
+    "Microsoft acquired Activision Blizzard in 2022 for nearly $69 billion, one of the largest deals in gaming history.",
+    "Serena Williams announced her retirement after the 2022 U.S. Open in New York.",
+    "The Paris Climate Agreement was signed in 2016, bringing together nations to fight global warming.",
+    "Pfizer and BioNTech developed the first widely distributed COVID-19 vaccine in 2020.",
+    "The 2008 financial crisis was triggered by the collapse of Lehman Brothers on Wall Street.",
+    "Barack Obama was elected President of the United States in 2008, becoming the first African-American president.",
+    "India landed Chandrayaan-3 on the lunar south pole in 2023, marking a historic achievement for ISRO.",
+    "The Nobel Peace Prize in 2014 was awarded to Malala Yousafzai for her fight for girls’ education.",
+    "Cristiano Ronaldo scored his 800th career goal during a match at Old Trafford in 2021.",
+    "The United Nations was founded in San Francisco in 1945 after World War II.",
+    "Beyoncé performed at Coachella 2018, an event later dubbed 'Beychella' by fans.",
+    "The Great Recession officially ended in June 2009 after massive stimulus spending.",
+    "Alibaba raised $25 billion in its 2014 IPO on the New York Stock Exchange.",
+    "Jeff Bezos stepped down as Amazon CEO in July 2021, handing over to Andy Jassy.",
+    "The Tokyo 2020 Olympics were postponed to 2021 due to the COVID-19 pandemic.",
+    "The Euro 2016 football championship was held across France, with Portugal emerging as the winner.",
+    "Netflix premiered 'Stranger Things' in 2016, a show that became a global pop culture phenomenon.",
+    "The iPhone was first introduced by Steve Jobs in January 2007 in San Francisco.",
+    "The Berlin Wall fell in 1989, symbolizing the end of the Cold War in Europe.",
+    "Queen Elizabeth II passed away in September 2022, ending the longest reign in British history.",
+    "Google acquired YouTube in 2006 for $1.65 billion, reshaping the digital media landscape.",
+]
+
+long_seq = """In 2023, OpenAI released GPT-4o at a major event in San Francisco, with CEO Sam Altman joining a panel on CNBC to discuss the company’s ambitions for artificial general intelligence. At nearly the same time, Google hosted its I/O conference in Mountain View, unveiling breakthroughs in translation and search while Sundar Pichai emphasized responsible AI. Meanwhile, Microsoft completed its $69 billion acquisition of Activision Blizzard, reshaping the gaming industry and prompting regulators in Brussels and Washington, D.C. to raise antitrust concerns.  
+
+Elsewhere, NASA announced that the Artemis II mission, scheduled for 2025, would send astronauts around the Moon for the first time in decades, while SpaceX prepared a Starship launch from Boca Chica, Texas. In Europe, the European Union finalized a sweeping AI Act in Brussels in 2024, hailed as the most comprehensive technology regulation since GDPR in 2018. At the same time, the United Nations hosted the COP28 climate summit in Dubai, where leaders including Emmanuel Macron, Narendra Modi, and Joe Biden pledged trillions of dollars in green investment.  
+
+In sports, Lionel Messi shocked the world by signing with Inter Miami in 2023 after leaving Paris Saint-Germain, while Cristiano Ronaldo continued his career with Al-Nassr in Saudi Arabia. The 2022 FIFA World Cup in Qatar had already set records for attendance and sponsorship revenue, with Adidas and Coca-Cola reporting billions in sales tied to the event. Meanwhile, the International Olympic Committee prepared for the Paris 2024 Summer Games, investing heavily in infrastructure projects across France.  
+
+On the cultural front, Taylor Swift’s Eras Tour began in Glendale in 2023 before expanding across Europe in 2024, generating over a billion dollars in ticket sales and boosting local economies from London to Berlin. Netflix, still riding the success of “Stranger Things” and “The Crown,” announced partnerships with South Korean studios in Seoul, investing $2.5 billion in new dramas by 2027. In Hollywood, the 2022 Academy Awards saw “CODA” win Best Picture, while the 2023 ceremony honored “Everything Everywhere All at Once,” with Michelle Yeoh becoming the first Asian woman to win Best Actress.  
+
+Meanwhile, in global finance, Bitcoin surged to an all-time high of $69,000 in November 2021 before crashing below $20,000 in 2022, causing turmoil for crypto exchanges like FTX, which filed for bankruptcy in Delaware after revelations about Sam Bankman-Fried’s empire. By 2024, BlackRock and Fidelity were filing ETF applications with the U.S. Securities and Exchange Commission, betting on mainstream adoption. In Asia, Alibaba and Tencent continued to expand their digital payment systems, while India’s UPI network processed more than 10 billion transactions in a single month.  
+
+Finally, political headlines dominated the world stage. In September 2022, Queen Elizabeth II passed away in Balmoral, prompting a global outpouring of grief and the accession of King Charles III. In the United States, the 2024 presidential race heated up with debates in Washington and rallies in key swing states like Pennsylvania, Michigan, and Arizona. Meanwhile, leaders gathered at the G20 Summit in New Delhi in 2023, where Prime Minister Narendra Modi welcomed counterparts from China, Japan, and the European Union, emphasizing collaboration in technology, trade, and climate resilience. Across all these events, the interplay of innovation, regulation, culture, and geopolitics underscored how interconnected the twenty-first century has become.
+"""
+DEFAULT_TEXTS.append(long_seq)
+
+DEFAULT_LABELS: List[str] = [
+    "Person",
+    "Organization",
+    "Location",
+    "Event",
+    "Date",
+    "Money",
+]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a single GLiNER NER batch with and without inference packing.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="urchade/gliner_small-v2.1",
+        help="Model name or local path to load with GLiNER.from_pretrained",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help="Device to run inference on (e.g. 'cpu', 'cuda', 'cuda:0')",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=4,
+        help="Batch size to use for the GLiNER dataloader",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Confidence threshold passed to GLiNER.run",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=None,
+        help="Override maximum packed sequence length (defaults to model.config.max_len)",
+    )
+    parser.add_argument(
+        "--streams-per-batch",
+        type=int,
+        default=32,
+        help="Number of packed streams to generate per batch",
+    )
+    return parser.parse_args()
+
+
+def _sync_if_cuda(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+
+
+def _format_prediction(example_id: int, text: str, entities: Sequence[dict]) -> str:
+    header = f"Example {example_id}"
+    body_lines = [textwrap.fill(text, width=100, initial_indent="  ", subsequent_indent="  ")]
+    if not entities:
+        body_lines.append("  (no entities above threshold)")
+    else:
+        for ent in entities:
+            snippet = ent["text"].replace("\n", " ")
+            label = ent["label"]
+            score = ent.get("score", 0.0)
+            start = ent.get("start")
+            end = ent.get("end")
+            body_lines.append(
+                f"  - '{snippet}' ({label}, score={score:.2f}, span={start}:{end})"
+            )
+    return "\n".join([header] + body_lines)
+
+
+def _display_predictions(texts: Sequence[str], predictions: Sequence[Sequence[dict]]) -> None:
+    print("NER predictions:")
+    for idx, (text, ents) in enumerate(zip(texts, predictions), start=1):
+        print(_format_prediction(idx, text, ents))
+        print()
+
+
+def _run_once(
+    model: GLiNER,
+    *,
+    texts: Sequence[str],
+    labels: Sequence[str],
+    batch_size: int,
+    threshold: float,
+    device: torch.device,
+    packing_config: InferencePackingConfig | None,
+) -> tuple[List[List[dict]], float]:
+    _sync_if_cuda(device)
+    start = time.perf_counter()
+    predictions = model.run(
+        list(texts),
+        list(labels),
+        batch_size=batch_size,
+        threshold=threshold,
+        packing_config=packing_config,
+    )
+    _sync_if_cuda(device)
+    elapsed = time.perf_counter() - start
+    # The model returns a tuple when num_gen_sequences > 1; enforce list typing for consistency.
+    return [list(example) for example in predictions], elapsed
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.batch_size < 1:
+        raise ValueError("--batch-size must be >= 1")
+    if args.streams_per_batch < 1:
+        raise ValueError("--streams-per-batch must be >= 1")
+
+    texts: List[str] = list(DEFAULT_TEXTS)
+    labels: List[str] = list(DEFAULT_LABELS)
+
+    device = torch.device(args.device)
+    try:
+        model = GLiNER.from_pretrained(args.model, map_location=str(device))
+    except Exception as exc:  # pragma: no cover - network / I/O failures
+        raise SystemExit(
+            "Failed to load GLiNER model. Use --model with a local path or ensure network access."
+        ) from exc
+    model.to(device)
+    model.eval()
+
+    tokenizer = model.data_processor.transformer_tokenizer
+    sep_token_id = getattr(tokenizer, "sep_token_id", None)
+    if sep_token_id is None:
+        sep_token_id = getattr(tokenizer, "eos_token_id", None)
+    if sep_token_id is None:
+        sep_token_id = getattr(tokenizer, "pad_token_id", None)
+
+    max_length = args.max_length or getattr(model.config, "max_len", None)
+    if max_length is None:
+        raise ValueError("Unable to infer max sequence length for packing; please pass --max-length")
+
+    packing_config = InferencePackingConfig(
+        max_length=int(max_length),
+        sep_token_id=sep_token_id,
+        streams_per_batch=args.streams_per_batch,
+    )
+
+    print("Running baseline (no packing)...")
+    baseline_preds, baseline_time = _run_once(
+        model,
+        texts=texts,
+        labels=labels,
+        batch_size=args.batch_size,
+        threshold=args.threshold,
+        device=device,
+        packing_config=None,
+    )
+
+    print("Running with inference packing...")
+    packed_preds, packed_time = _run_once(
+        model,
+        texts=texts,
+        labels=labels,
+        batch_size=args.batch_size,
+        threshold=args.threshold,
+        device=device,
+        packing_config=packing_config,
+    )
+    _display_predictions(texts, packed_preds)
+
+    identical = baseline_preds == packed_preds
+
+    print("Timing summary:")
+    print(f"  Without packing: {baseline_time:.3f} s")
+    print(f"  With packing   : {packed_time:.3f} s")
+    if packed_time > 0:
+        print(f"  Speedup        : {baseline_time / packed_time:.2f}x")
+    print(f"Predictions identical: {identical}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/bench_infer_packing.py
+++ b/bench/bench_infer_packing.py
@@ -7,12 +7,14 @@ import argparse
 import json
 import time
 from dataclasses import asdict, dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional, Sequence
 
 import numpy as np
 import torch
 from transformers import AutoModel, AutoTokenizer
 
+from gliner import GLiNER
+from gliner.data_processing.collator import DataCollator
 from gliner.infer_packing import InferencePackingConfig, pack_requests
 
 
@@ -53,6 +55,25 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--device", type=str, default="cpu", help="Device to benchmark on")
     parser.add_argument("--warmup", type=int, default=10, help="Number of warmup iterations")
     parser.add_argument("--iters", type=int, default=100, help="Number of timed iterations")
+    parser.add_argument(
+        "--gliner_model",
+        type=str,
+        default=None,
+        help=(
+            "Benchmark the full GLiNER network instead of only the encoder by "
+            "providing a model repository or path"
+        ),
+    )
+    parser.add_argument(
+        "--gliner_labels",
+        type=str,
+        nargs="+",
+        default=None,
+        help=(
+            "Optional list of entity labels to use when running the GLiNER benchmark. "
+            "Defaults to a single generic label."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -82,6 +103,37 @@ def _generate_lengths(args: argparse.Namespace) -> List[int]:
     raise ValueError(f"Unsupported scenario: {args.scenario}")
 
 
+def _build_dummy_text(length: int) -> str:
+    tokens = [f"entity{i % 7}" for i in range(max(1, int(length)))]
+    return " ".join(tokens)
+
+
+def _prepare_gliner_inputs(
+    model: GLiNER,
+    lengths: Sequence[int],
+    labels: Sequence[str],
+) -> Dict[str, torch.Tensor]:
+    texts = [_build_dummy_text(length) for length in lengths]
+    input_x, _, _ = model.prepare_texts(texts)
+    collator = DataCollator(
+        model.config,
+        data_processor=model.data_processor,
+        prepare_labels=False,
+        entity_types=list(labels),
+    )
+    batch = collator(input_x)
+    tensor_inputs = {
+        key: value for key, value in batch.items() if isinstance(value, torch.Tensor)
+    }
+    if "input_ids" not in tensor_inputs or "attention_mask" not in tensor_inputs:
+        raise KeyError("GLiNER collator did not return the expected tensors")
+    return tensor_inputs
+
+
+def _to_device(inputs: Dict[str, torch.Tensor], device: torch.device) -> Dict[str, torch.Tensor]:
+    return {key: value.to(device) for key, value in inputs.items()}
+
+
 def _build_requests(lengths: List[int], vocab_size: int, pad_token_id: int) -> List[Dict[str, List[int]]]:
     requests: List[Dict[str, List[int]]] = []
     token = 0
@@ -109,6 +161,34 @@ def _collate_baseline(requests: List[Dict[str, List[int]]], pad_token_id: int) -
         input_ids[row, :length] = torch.tensor(tokens, dtype=torch.long)
         attention_mask[row, :length] = 1
     return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+
+def _measure_gliner(
+    model: GLiNER,
+    inputs: Dict[str, torch.Tensor],
+    *,
+    warmup: int,
+    iters: int,
+    device: torch.device,
+    packing_config: Optional[InferencePackingConfig] = None,
+) -> float:
+    with torch.inference_mode():
+        for _ in range(max(0, warmup)):
+            kwargs = dict(inputs)
+            if packing_config is not None:
+                kwargs["packing_config"] = packing_config
+            model(**kwargs)
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        start = time.perf_counter()
+        for _ in range(max(1, iters)):
+            kwargs = dict(inputs)
+            if packing_config is not None:
+                kwargs["packing_config"] = packing_config
+            model(**kwargs)
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+    return time.perf_counter() - start
 
 
 def _measure(
@@ -145,71 +225,146 @@ def main() -> None:
         torch.cuda.manual_seed_all(1337)
         torch.backends.cudnn.deterministic = True
 
-    tokenizer = AutoTokenizer.from_pretrained(args.model)
-    model = AutoModel.from_pretrained(args.model)
-    model.to(device)
-    model.eval()
-
-    pad_token_id = tokenizer.pad_token_id
-    if pad_token_id is None:
-        pad_token_id = tokenizer.eos_token_id or 0
-    vocab_size = getattr(tokenizer, "vocab_size", len(tokenizer))
-    if vocab_size is None:
-        vocab_size = len(tokenizer)
-    vocab_size = int(vocab_size)
-    if vocab_size <= 1:
-        raise ValueError("Tokenizer vocabulary size must exceed 1")
     lengths = _generate_lengths(args)
     lengths = [min(length, args.max_length) for length in lengths]
-    requests = _build_requests(lengths, vocab_size, pad_token_id)
-    real_tokens = sum(len(req["input_ids"]) for req in requests)
-
-    baseline_inputs = _collate_baseline(requests, pad_token_id)
-    baseline_inputs = {k: v.to(device) for k, v in baseline_inputs.items()}
-
-    cfg = InferencePackingConfig(
-        max_length=args.max_length,
-        sep_token_id=tokenizer.sep_token_id,
-        streams_per_batch=1,
-    )
-    packed = pack_requests(requests, cfg, pad_token_id)
-    mask_dtype = baseline_inputs["attention_mask"].dtype
-    packed_inputs = {
-        "input_ids": packed.input_ids.to(device),
-        "attention_mask": packed.pair_attention_mask.to(device=device, dtype=mask_dtype),
-    }
-
     warmup = args.warmup
     iters = args.iters
 
-    baseline_time = _measure(model, baseline_inputs, warmup=warmup, iters=iters, device=device)
-    packed_time = _measure(model, packed_inputs, warmup=warmup, iters=iters, device=device)
+    if args.gliner_model:
+        labels = args.gliner_labels or ["entity"]
+        gliner_model = GLiNER.from_pretrained(args.gliner_model, map_location=device.type)
+        gliner_model.to(device)
+        gliner_model.eval()
 
-    padded_tokens = baseline_inputs["input_ids"].size(1) * len(requests)
-    baseline_stats = BenchmarkStats(
-        tokens_per_s=(real_tokens * iters) / baseline_time,
-        examples_per_s=(len(requests) * iters) / baseline_time,
-        padding_ratio=1.0 - (real_tokens / padded_tokens) if padded_tokens else 0.0,
-    )
+        gliner_inputs_cpu = _prepare_gliner_inputs(gliner_model, lengths, labels)
+        baseline_inputs = _to_device(gliner_inputs_cpu, device)
 
-    packed_tokens = packed.input_ids.size(1) * packed.input_ids.size(0)
-    packed_stats = BenchmarkStats(
-        tokens_per_s=(real_tokens * iters) / packed_time,
-        examples_per_s=(len(requests) * iters) / packed_time,
-        padding_ratio=1.0 - (real_tokens / packed_tokens) if packed_tokens else 0.0,
-    )
+        attention_mask_cpu = gliner_inputs_cpu["attention_mask"]
+        input_ids_cpu = gliner_inputs_cpu["input_ids"]
+        requests = []
+        for row_ids, row_mask in zip(input_ids_cpu, attention_mask_cpu):
+            length = int(row_mask.sum().item())
+            requests.append({"input_ids": row_ids[:length].tolist()})
 
-    result = {
-        "device": device.type,
-        "model": args.model,
-        "scenario": args.scenario,
-        "batch_size": args.batch_size,
-        "max_length": args.max_length,
-        "baseline": baseline_stats,
-        "packed": packed_stats,
-        "speedup_tokens_per_s": packed_stats.tokens_per_s / baseline_stats.tokens_per_s,
-        "streams": packed.input_ids.size(0),
-    }
+        real_tokens = sum(len(req["input_ids"]) for req in requests)
+        padded_tokens = int(input_ids_cpu.size(0) * input_ids_cpu.size(1))
+
+        tokenizer = gliner_model.data_processor.transformer_tokenizer
+        pad_token_id = tokenizer.pad_token_id or 0
+        cfg = InferencePackingConfig(
+            max_length=args.max_length,
+            sep_token_id=tokenizer.sep_token_id,
+            streams_per_batch=1,
+        )
+        packed = pack_requests(requests, cfg, pad_token_id)
+
+        baseline_time = _measure_gliner(
+            gliner_model,
+            baseline_inputs,
+            warmup=warmup,
+            iters=iters,
+            device=device,
+            packing_config=None,
+        )
+        packed_time = _measure_gliner(
+            gliner_model,
+            baseline_inputs,
+            warmup=warmup,
+            iters=iters,
+            device=device,
+            packing_config=cfg,
+        )
+
+        baseline_stats = BenchmarkStats(
+            tokens_per_s=(real_tokens * iters) / baseline_time,
+            examples_per_s=(len(requests) * iters) / baseline_time,
+            padding_ratio=1.0 - (real_tokens / padded_tokens) if padded_tokens else 0.0,
+        )
+
+        packed_tokens = packed.input_ids.size(1) * packed.input_ids.size(0)
+        packed_stats = BenchmarkStats(
+            tokens_per_s=(real_tokens * iters) / packed_time,
+            examples_per_s=(len(requests) * iters) / packed_time,
+            padding_ratio=1.0 - (real_tokens / packed_tokens) if packed_tokens else 0.0,
+        )
+
+        result = {
+            "device": device.type,
+            "model": args.gliner_model,
+            "scenario": args.scenario,
+            "batch_size": args.batch_size,
+            "max_length": args.max_length,
+            "baseline": baseline_stats,
+            "packed": packed_stats,
+            "speedup_tokens_per_s": packed_stats.tokens_per_s / baseline_stats.tokens_per_s,
+            "streams": packed.input_ids.size(0),
+        }
+    else:
+        tokenizer = AutoTokenizer.from_pretrained(args.model)
+        model = AutoModel.from_pretrained(args.model)
+        model.to(device)
+        model.eval()
+
+        pad_token_id = tokenizer.pad_token_id
+        if pad_token_id is None:
+            pad_token_id = tokenizer.eos_token_id or 0
+        vocab_size = getattr(tokenizer, "vocab_size", len(tokenizer))
+        if vocab_size is None:
+            vocab_size = len(tokenizer)
+        vocab_size = int(vocab_size)
+        if vocab_size <= 1:
+            raise ValueError("Tokenizer vocabulary size must exceed 1")
+
+        requests = _build_requests(lengths, vocab_size, pad_token_id)
+        real_tokens = sum(len(req["input_ids"]) for req in requests)
+
+        baseline_inputs = _collate_baseline(requests, pad_token_id)
+        baseline_inputs = {k: v.to(device) for k, v in baseline_inputs.items()}
+
+        cfg = InferencePackingConfig(
+            max_length=args.max_length,
+            sep_token_id=tokenizer.sep_token_id,
+            streams_per_batch=1,
+        )
+        packed = pack_requests(requests, cfg, pad_token_id)
+        mask_dtype = baseline_inputs["attention_mask"].dtype
+        packed_inputs = {
+            "input_ids": packed.input_ids.to(device),
+            "attention_mask": packed.pair_attention_mask.to(device=device, dtype=mask_dtype),
+        }
+
+        baseline_time = _measure(
+            model, baseline_inputs, warmup=warmup, iters=iters, device=device
+        )
+        packed_time = _measure(
+            model, packed_inputs, warmup=warmup, iters=iters, device=device
+        )
+
+        padded_tokens = baseline_inputs["input_ids"].size(1) * len(requests)
+        baseline_stats = BenchmarkStats(
+            tokens_per_s=(real_tokens * iters) / baseline_time,
+            examples_per_s=(len(requests) * iters) / baseline_time,
+            padding_ratio=1.0 - (real_tokens / padded_tokens) if padded_tokens else 0.0,
+        )
+
+        packed_tokens = packed.input_ids.size(1) * packed.input_ids.size(0)
+        packed_stats = BenchmarkStats(
+            tokens_per_s=(real_tokens * iters) / packed_time,
+            examples_per_s=(len(requests) * iters) / packed_time,
+            padding_ratio=1.0 - (real_tokens / packed_tokens) if packed_tokens else 0.0,
+        )
+
+        result = {
+            "device": device.type,
+            "model": args.model,
+            "scenario": args.scenario,
+            "batch_size": args.batch_size,
+            "max_length": args.max_length,
+            "baseline": baseline_stats,
+            "packed": packed_stats,
+            "speedup_tokens_per_s": packed_stats.tokens_per_s / baseline_stats.tokens_per_s,
+            "streams": packed.input_ids.size(0),
+        }
 
     json_payload = {
         **{k: v for k, v in result.items() if k not in {"baseline", "packed"}},

--- a/bench/bench_infer_packing.py
+++ b/bench/bench_infer_packing.py
@@ -328,10 +328,17 @@ def main() -> None:
         )
         packed = pack_requests(requests, cfg, pad_token_id)
         mask_dtype = baseline_inputs["attention_mask"].dtype
-        packed_inputs = {
-            "input_ids": packed.input_ids.to(device),
-            "attention_mask": packed.pair_attention_mask.to(device=device, dtype=mask_dtype),
-        }
+
+        if args.model in ["microsoft/deberta-v3-small", "microsoft/deberta-v3-base"]:
+            packed_inputs = {
+                "input_ids": packed.input_ids.to(device),
+                "attention_mask": packed.attention_mask.to(device=device, dtype=mask_dtype),
+            }
+        else:
+            packed_inputs = {
+                "input_ids": packed.input_ids.to(device),
+                "attention_mask": packed.pair_attention_mask.to(device=device, dtype=mask_dtype),
+            }
 
         baseline_time = _measure(
             model, baseline_inputs, warmup=warmup, iters=iters, device=device


### PR DESCRIPTION
## Summary
- document how to enable and benchmark inference-time sequence packing in README_Extended
- bench/bench_gliner_e2e.py to support full GLiNER models benchmarking

------